### PR TITLE
Fix for problems in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ scipy
 autograd
 lightkurve
 statsmodels
-sklearn
-future==0.16.0
+scikit-learn
 pybind11
 k2sc
 scikit-image >= 0.14.0

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from numpy.distutils.core import setup, Extension
-from numpy.distutils.misc_util import Configuration
-import distutils.sysconfig as ds
+
 from setuptools import setup
-import os, codecs, re
+import os
+import codecs
+import re
 
 long_description = 'A Python package for doing photometry of very bright stars in the Kepler/K2 mission using halo photometry, constructing the light curve as a linear combination of pixels.\
       We minimize total variation (TV) of the final light curve with respect to the weights of the individual pixels using analytic gradient descent.\


### PR DESCRIPTION
This PR modifies the `requirements.txt` file to fix the following two problems:

- Change the name of the required `sklearn` package to `scikit-learn`. This is recommended, and will in the future result in an error. Read more here:
  https://github.com/scikit-learn/sklearn-pypi-package

- Removed fixed version of `future`, since it look to be unnecessary. This also avoids a security issue in `future`. Read more here:
https://github.com/advisories/GHSA-v3c5-jqr6-7qm8